### PR TITLE
Add support to multiple pockets

### DIFF
--- a/custom_components/coverflex/api.py
+++ b/custom_components/coverflex/api.py
@@ -55,7 +55,7 @@ class CoverflexAPI:
         except aiohttp.ClientError as err:
             _LOGGER.error(err)
 
-    async def getBalance(self, token) -> Pocket:
+    async def getBalances(self, token):
         """Issue CARD requests."""
         try:
             _LOGGER.debug("Getting the card details...")
@@ -67,7 +67,8 @@ class CoverflexAPI:
             ) as res:
                 if res.status == 200 and res.content_type == "application/json":
                     json = await res.json()
-                    return Pocket(json['pockets'][0])
+                    pockets = map(lambda x: Pocket(x), json['pockets'])
+                    return  list(pockets)
                 raise Exception("Could not fetch the card balance from API")
         except aiohttp.ClientError as err:
             _LOGGER.error(err)

--- a/custom_components/coverflex/interfaces.py
+++ b/custom_components/coverflex/interfaces.py
@@ -1,7 +1,6 @@
 """Card Class."""
 
 from datetime import datetime, timezone
-from homeassistant.util import dt
 
 class Card:
     """Represents a Coverflex card."""
@@ -55,6 +54,10 @@ class Pocket:
     @property
     def currency(self) -> str:
         return self._data["balance"]["currency"]
+
+    @property
+    def type(self):
+        return self._data["type"]
 
 
 class Transaction:


### PR DESCRIPTION
The "Pockets" API returns multiple pockets, and the previous version of this repo was indexing only the first one.
As far as I can tell, it has a "benefits", a "meal" and a "main", but as it may be dynamic per card the change assumes any number of pockets.

So, I changed the initialization to load 1 sensor per "pocket", adding the "type" to the name of the sensor, and the id of the pocket to the unique_id.
