### PR TITLE
Feat/update service

### DIFF
--- a/custom_components/coverflex/__init__.py
+++ b/custom_components/coverflex/__init__.py
@@ -3,20 +3,30 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+import voluptuous as vol
+
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.http import StaticPathConfig
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import CoverflexAPI
 from .coordinator import CoverflexCoordinator
-from .const import DOMAIN
+from .const import DOMAIN, SERVICE_REFRESH
 
 __version__ = "2.0.0"
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+_SERVICE_REFRESH_SCHEMA = vol.Schema(
+    {
+        vol.Optional("config_entry_id"): cv.string,
+    }
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -37,6 +47,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Register the domain service only once (first entry setup)
+    if not hass.services.has_service(DOMAIN, SERVICE_REFRESH):
+
+        async def handle_refresh(call: ServiceCall) -> None:
+            """Handle the coverflex.refresh service call."""
+            entry_id: str | None = call.data.get("config_entry_id")
+            coordinators: dict[str, CoverflexCoordinator] = hass.data.get(DOMAIN, {})
+
+            if entry_id:
+                target = coordinators.get(entry_id)
+                if target is None:
+                    raise ServiceValidationError(
+                        f"No Coverflex entry found with config_entry_id '{entry_id}'."
+                    )
+                await target.async_force_refresh()
+            else:
+                for coord in coordinators.values():
+                    await coord.async_force_refresh()
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_REFRESH,
+            handle_refresh,
+            schema=_SERVICE_REFRESH_SCHEMA,
+        )
+
     return True
 
 
@@ -45,4 +82,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unloaded:
         hass.data[DOMAIN].pop(entry.entry_id)
+        # Remove the domain service when the last entry is unloaded
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_REFRESH)
     return unloaded

--- a/custom_components/coverflex/const.py
+++ b/custom_components/coverflex/const.py
@@ -28,3 +28,6 @@ UPDATE_INTERVAL = timedelta(minutes=30)
 
 # Maximum number of transactions to fetch and expose per pocket
 DEFAULT_TRANSACTIONS_COUNT = 20
+
+# Service names
+SERVICE_REFRESH = "refresh"

--- a/custom_components/coverflex/coordinator.py
+++ b/custom_components/coverflex/coordinator.py
@@ -187,3 +187,8 @@ class CoverflexCoordinator(DataUpdateCoordinator[CoverflexData]):
     ) -> None:
         """Called by the reauth flow after a successful OTP login to persist new tokens."""
         await self._async_save_tokens(refresh_token, user_agent_token)
+
+    async def async_force_refresh(self) -> None:
+        """Force a full refresh, clearing the balance cache so all transactions are re-fetched."""
+        self._last_balances.clear()
+        await self.async_refresh()

--- a/custom_components/coverflex/sensor.py
+++ b/custom_components/coverflex/sensor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from babel.dates import format_date as babel_format_date
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -21,6 +23,18 @@ from .coordinator import CoverflexCoordinator
 from .interfaces import Pocket
 
 _LOGGER = logging.getLogger(__name__)
+
+_MONTH_ABBR_EN = ("Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+
+def _format_transaction_date(dt_obj, lang: str) -> str:
+    """Return a locale-aware date string in 'dd Mmm - HH:MM' format."""
+    try:
+        month = babel_format_date(dt_obj, format="MMM", locale=lang).capitalize()
+    except Exception:  # noqa: BLE001
+        month = _MONTH_ABBR_EN[dt_obj.month - 1]
+    return f"{dt_obj.day:02d} {month} - {dt_obj.strftime('%H:%M')}"
 
 
 async def async_setup_entry(
@@ -95,11 +109,12 @@ class CoverflexPocketSensor(CoordinatorEntity[CoverflexCoordinator], SensorEntit
         card = self.coordinator.data.card
         pocket = self._pocket
         raw_transactions = self.coordinator.data.transactions.get(self._pocket_id, [])
+        lang = self.hass.config.language
         transactions = [
             {
-                "date": t.date,
+                "date": _format_transaction_date(t.date, lang),
                 "description": t.description,
-                "amount": t.amount,
+                "amount": f"{t.amount:.2f}",
                 "currency": t.currency,
             }
             for t in raw_transactions

--- a/custom_components/coverflex/sensor.py
+++ b/custom_components/coverflex/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.dt import as_local
 
 from .const import DOMAIN, ATTRIBUTION, DEFAULT_ICON
 from .coordinator import CoverflexCoordinator
@@ -30,11 +31,12 @@ _MONTH_ABBR_EN = ("Jan", "Feb", "Mar", "Apr", "May", "Jun",
 
 def _format_transaction_date(dt_obj, lang: str) -> str:
     """Return a locale-aware date string in 'dd Mmm - HH:MM' format."""
+    local_dt = as_local(dt_obj)
     try:
-        month = babel_format_date(dt_obj, format="MMM", locale=lang).capitalize()
+        month = babel_format_date(local_dt, format="MMM", locale=lang).capitalize()
     except Exception:  # noqa: BLE001
-        month = _MONTH_ABBR_EN[dt_obj.month - 1]
-    return f"{dt_obj.day:02d} {month} - {dt_obj.strftime('%H:%M')}"
+        month = _MONTH_ABBR_EN[local_dt.month - 1]
+    return f"{local_dt.day:02d} {month} - {local_dt.strftime('%H:%M')}"
 
 
 async def async_setup_entry(

--- a/custom_components/coverflex/services.yaml
+++ b/custom_components/coverflex/services.yaml
@@ -1,0 +1,8 @@
+refresh:
+  fields:
+    config_entry_id:
+      required: false
+      example: "abc123def456"
+      selector:
+        config_entry:
+          integration: coverflex

--- a/custom_components/coverflex/strings.json
+++ b/custom_components/coverflex/strings.json
@@ -46,5 +46,17 @@
             "already_configured": "Coverflex is already configured.",
             "reauth_successful": "Re-authentication was successful."
         }
+    },
+    "services": {
+        "refresh": {
+            "name": "Refresh",
+            "description": "Forces a full refresh of balances and transactions, bypassing the update interval and re-fetching all transactions regardless of balance changes.",
+            "fields": {
+                "config_entry_id": {
+                    "name": "Config entry",
+                    "description": "The Coverflex account to refresh. Leave empty to refresh all configured accounts."
+                }
+            }
+        }
     }
 }

--- a/custom_components/coverflex/translations/en.json
+++ b/custom_components/coverflex/translations/en.json
@@ -46,5 +46,17 @@
             "already_configured": "Coverflex is already configured.",
             "reauth_successful": "Re-authentication was successful."
         }
+    },
+    "services": {
+        "refresh": {
+            "name": "Refresh",
+            "description": "Forces a full refresh of balances and transactions, bypassing the update interval and re-fetching all transactions regardless of balance changes.",
+            "fields": {
+                "config_entry_id": {
+                    "name": "Config entry",
+                    "description": "The Coverflex account to refresh. Leave empty to refresh all configured accounts."
+                }
+            }
+        }
     }
 }

--- a/custom_components/coverflex/translations/pt.json
+++ b/custom_components/coverflex/translations/pt.json
@@ -46,5 +46,17 @@
             "already_configured": "A integração Coverflex já está configurada.",
             "reauth_successful": "A reautenticação foi concluída com sucesso."
         }
+    },
+    "services": {
+        "refresh": {
+            "name": "Actualizar",
+            "description": "Força uma actualização completa dos saldos e movimentos, ignorando o intervalo de actualização e obtendo todos os movimentos independentemente de alterações de saldo.",
+            "fields": {
+                "config_entry_id": {
+                    "name": "Integração",
+                    "description": "A conta Coverflex a actualizar. Deixar em branco para actualizar todas as contas configuradas."
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new `refresh` service to the Coverflex integration, allowing users to force a full refresh of balances and transactions for one or all configured accounts. It also improves the formatting of transaction dates to be locale-aware and enhances the display of transaction amounts. The main changes are grouped as follows:

**New Service: Force Refresh**

* Added a `refresh` service that can be called to bypass the update interval and re-fetch all transactions and balances. The service can target a specific config entry or all entries and is registered/unregistered dynamically based on integration setup/unload. (`custom_components/coverflex/__init__.py`, `custom_components/coverflex/const.py`, `custom_components/coverflex/services.yaml`, `custom_components/coverflex/strings.json`, `custom_components/coverflex/translations/en.json`, `custom_components/coverflex/translations/pt.json`) [[1]](diffhunk://#diff-381f384ae88e11785946625309dee649477d87de2dcca821ac95930c7192a83cR6-R30) [[2]](diffhunk://#diff-381f384ae88e11785946625309dee649477d87de2dcca821ac95930c7192a83cR50-R76) [[3]](diffhunk://#diff-381f384ae88e11785946625309dee649477d87de2dcca821ac95930c7192a83cR85-R87) [[4]](diffhunk://#diff-431514c92c4ba5ca79cf220e2c8542568b741c4061c7587c777b31421914a7eaR31-R33) [[5]](diffhunk://#diff-94abc8ed6b59820dbde1d5f59a56627ac92ce96a57401d5976d36b8293ba6d52R1-R8) [[6]](diffhunk://#diff-ae93dd0ffe58aaa858184501701094a88f2d1b31e43500680ee4b243d166571cR49-R60) [[7]](diffhunk://#diff-6e62c3b1d7e8586ac281c58a7bc20c20ab853280e9bc8739cfe825afda6aeed7R49-R60) [[8]](diffhunk://#diff-b057d38a86b5a5a8d868164c120ec4f0c9fdb1118b726fdc7b5ad48542c0a7a0R49-R60)
* Implemented `async_force_refresh` in `CoverflexCoordinator` to clear cached balances and force a full data refresh. (`custom_components/coverflex/coordinator.py`)

**Transaction Display Improvements**

* Transaction dates are now formatted in a locale-aware way (e.g., "02 Mar - 14:30"), with a fallback to English abbreviations if localization fails. (`custom_components/coverflex/sensor.py`) [[1]](diffhunk://#diff-01d6156a9b5fffa3d2d67953496429623f981aa497c77bae9304cb533d9bc477R7-R8) [[2]](diffhunk://#diff-01d6156a9b5fffa3d2d67953496429623f981aa497c77bae9304cb533d9bc477R27-R38) [[3]](diffhunk://#diff-01d6156a9b5fffa3d2d67953496429623f981aa497c77bae9304cb533d9bc477R112-R117)
* Transaction amounts are now displayed as strings with two decimal places for consistency. (`custom_components/coverflex/sensor.py`)

These changes improve both the user experience and the maintainability of the integration by providing a manual refresh option and better-formatted transaction information.